### PR TITLE
valueReference answerOption support

### DIFF
--- a/app/scripts/fhir/R4/lformsFHIR.js
+++ b/app/scripts/fhir/R4/lformsFHIR.js
@@ -23875,7 +23875,15 @@ function addSDCImportFns(ns) {
             if (option[optionKey[0]].system !== undefined) {
               answer.system = option[optionKey[0]].system;
             }
-          } else {
+          }
+          // Add support for valueReference
+          else if (optionKey[0] === 'valueReference') {
+            if(option[optionKey[0]].reference !== undefined) answer.reference = option[optionKey[0]].reference;
+            if(option[optionKey[0]].display !== undefined) answer.text = option[optionKey[0]].display;
+            if(option[optionKey[0]].type !== undefined) answer.type = option[optionKey[0]].type;
+            if(option[optionKey[0]].identifier !== undefined) answer.identifier = option[optionKey[0]].identifier;
+          }
+          else {
             answer.text = option[optionKey[0]].toString();
           }
         }

--- a/app/scripts/fhir/R4/sdc-import.js
+++ b/app/scripts/fhir/R4/sdc-import.js
@@ -200,6 +200,13 @@ function addSDCImportFns(ns) {
               answer.system = option[optionKey[0]].system;
             }
           }
+          // Add support for valueReference
+          else if (optionKey[0] === 'valueReference') {
+            if(option[optionKey[0]].reference !== undefined) answer.reference = option[optionKey[0]].reference;
+            if(option[optionKey[0]].display !== undefined) answer.text = option[optionKey[0]].display;
+            if(option[optionKey[0]].type !== undefined) answer.type = option[optionKey[0]].type;
+            if(option[optionKey[0]].identifier !== undefined) answer.identifier = option[optionKey[0]].identifier;
+          }
           else {
             answer.text = option[optionKey[0]].toString();
           }

--- a/app/scripts/fhir/STU3/sdc-import.js
+++ b/app/scripts/fhir/STU3/sdc-import.js
@@ -219,7 +219,14 @@ function addSDCImportFns(ns) {
               answer.system = option[optionKey[0]].system;
             }
           }
-          else {
+        // Add support for valueReference
+          else if (optionKey[0] === 'valueReference') {
+            if(option[optionKey[0]].reference !== undefined) answer.reference = option[optionKey[0]].reference;
+            if(option[optionKey[0]].display !== undefined) answer.text = option[optionKey[0]].display;
+            if(option[optionKey[0]].type !== undefined) answer.type = option[optionKey[0]].type;
+            if(option[optionKey[0]].identifier !== undefined) answer.identifier = option[optionKey[0]].identifier;
+          }
+        else {
             answer.text = option[optionKey[0]].toString();
           }
         }

--- a/app/scripts/fhir/sdc-common.js
+++ b/app/scripts/fhir/sdc-common.js
@@ -39,8 +39,10 @@ function addCommonSDCFns(ns) {
     "TX": 'String',
     "BL": 'Boolean',
     "URL": 'Url',
-    "CNE": 'Coding',
-    "CWE": 'Coding',
+    "CNE": 'Reference',
+    "CWE": 'Reference',
+    //"CNE": 'Coding',
+    //"CWE": 'Coding',
     "QTY": 'Quantity'
   };
 

--- a/app/scripts/fhir/sdc-common.js
+++ b/app/scripts/fhir/sdc-common.js
@@ -39,10 +39,8 @@ function addCommonSDCFns(ns) {
     "TX": 'String',
     "BL": 'Boolean',
     "URL": 'Url',
-    "CNE": 'Reference',
-    "CWE": 'Reference',
-    //"CNE": 'Coding',
-    //"CWE": 'Coding',
+    "CNE": 'Coding',
+    "CWE": 'Coding',
     "QTY": 'Quantity'
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lforms",
-  "version": "26.1.0",
+  "version": "26.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Allows for the lforms widget to read `valueReference` type `answerOptions` when converting from FHIR 
Questionnaire to LForm. As a result, the reference attribute of valueReference stays intact throughout conversion, and the `display` field of the valueReference object is shown on the widget UI.

**To test:** Launch the Abstractor from the [valueReference_answerOptions_support](https://github.com/mcode/abstraction-tool/tree/valueReference_answerOptions_support) branch. This will allow `package.json` of the abstraction tool to access this branch of lforms as a dependency. As a result of running the abstraction tool, an LForm object should be logged to the console:
LForm.items[20].answers[0] should contain a reference and a text value.
LForm.items[20].value should also contain a reference and a text value.
The abstractor should display the `text` value in the corresponding Value spot within the UI.
